### PR TITLE
Operator State

### DIFF
--- a/src/main/java/frc/lib/util/MatchCommand.java
+++ b/src/main/java/frc/lib/util/MatchCommand.java
@@ -20,7 +20,7 @@ public class MatchCommand<T extends Enum<T>> extends Command {
     /**
      * Create new MatchCommand. Note that the length of enumValues and commandValues must be the
      * same.
-     * 
+     *
      * @throws IllegalArgumentException when enumValues and commandValues have different lengths.
      */
     public MatchCommand(List<T> enumValues, List<Command> commandValues, Supplier<T> condition) {

--- a/src/main/java/frc/lib/util/MatchCommand.java
+++ b/src/main/java/frc/lib/util/MatchCommand.java
@@ -1,0 +1,85 @@
+package frc.lib.util;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.ConditionalCommand;
+import edu.wpi.first.wpilibj2.command.Subsystem;
+
+/**
+ * Similar to {@link ConditionalCommand} but allows commands for all variants of an enum instead.
+ */
+public class MatchCommand<T extends Enum<T>> extends Command {
+
+    private final Map<T, Command> map;
+    private final Supplier<T> condition;
+    private Command currentCommand;
+
+    /**
+     * Create new MatchCommand. Note that the length of enumValues and commandValues must be the
+     * same.
+     * 
+     * @throws IllegalArgumentException when enumValues and commandValues have different lengths.
+     */
+    public MatchCommand(List<T> enumValues, List<Command> commandValues, Supplier<T> condition) {
+        this.map = new HashMap<>();
+        this.condition = condition;
+        if (enumValues.size() != commandValues.size()) {
+            throw new IllegalArgumentException(
+                "enumValues.size() should equal commandValues.size(). It does not.");
+        }
+        for (int i = 0; i < enumValues.size(); i++) {
+            this.map.put(enumValues.get(i), commandValues.get(i));
+        }
+    }
+
+    @Override
+    public void initialize() {
+        T t = condition.get();
+        currentCommand = map.get(t);
+        if (currentCommand != null) {
+            currentCommand.initialize();
+            for (Subsystem s : currentCommand.getRequirements()) {
+                this.m_requirements.add(s);
+            }
+        }
+    }
+
+    @Override
+    public void execute() {
+        if (currentCommand != null) {
+            currentCommand.execute();
+        }
+    }
+
+    @Override
+    public void end(boolean interrupted) {
+        currentCommand.end(interrupted);
+        for (Subsystem s : currentCommand.getRequirements()) {
+            this.m_requirements.remove(s);
+        }
+    }
+
+    @Override
+    public boolean isFinished() {
+        return currentCommand == null || currentCommand.isFinished();
+    }
+
+    @Override
+    public boolean runsWhenDisabled() {
+        return map.values().stream().allMatch((x) -> x.runsWhenDisabled());
+    }
+
+    @Override
+    public InterruptionBehavior getInterruptionBehavior() {
+        if (map.values().stream()
+            .anyMatch((x) -> x.getInterruptionBehavior() == InterruptionBehavior.kCancelSelf)) {
+            return InterruptionBehavior.kCancelSelf;
+        } else {
+            return InterruptionBehavior.kCancelIncoming;
+        }
+    }
+
+}

--- a/src/main/java/frc/lib/util/photon/PhotonCameraWrapper.java
+++ b/src/main/java/frc/lib/util/photon/PhotonCameraWrapper.java
@@ -60,6 +60,10 @@ public class PhotonCameraWrapper {
      */
     public Optional<Pose2d> getInitialPose() {
         var res = inputs.result;
+        SmartDashboard.putNumber("Heartbeat", inputs.timeSinceLastHeartbeat);
+        if (inputs.timeSinceLastHeartbeat > 0.5) {
+            return Optional.empty();
+        }
         SmartDashboard.putNumber("lastTimePhton", res.getTimestampSeconds());
         if (res.hasTargets()) {
             var target = res.getBestTarget();

--- a/src/main/java/frc/lib/util/swerve/SwerveModuleIO.java
+++ b/src/main/java/frc/lib/util/swerve/SwerveModuleIO.java
@@ -12,8 +12,8 @@ public interface SwerveModuleIO {
         public double driveMotorSelectedSensorVelocity;
         public double angleMotorSelectedPosition;
         public double absolutePositionAngleEncoder;
-        public double driveMotorTemp;
-        public double angleMotorTemp;
+        // public double driveMotorTemp;
+        // public double angleMotorTemp;
     }
 
     public default void updateInputs(SwerveModuleInputs inputs) {}

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -282,9 +282,8 @@ public final class Constants {
         }
 
         public static final HolonomicPathFollowerConfig pathFollowerConfig =
-            new HolonomicPathFollowerConfig(new PIDConstants(5.0, 0, 0), // Translation constants
-                new PIDConstants(AUTO_ROTATION_KP, AUTO_ROTATION_KI, AUTO_ROTATION_KD), // Rotation
-                                                                                        // constants
+            new HolonomicPathFollowerConfig(new PIDConstants(5.0, 0, 0),
+                new PIDConstants(AUTO_ROTATION_KP, AUTO_ROTATION_KI, AUTO_ROTATION_KD),
                 // Drive base radius (distance from center to furthest module)
                 maxSpeed, MOD0_MODOFFSET.getNorm(), new ReplanningConfig());
     }

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -37,6 +37,11 @@ public final class Constants {
     public static final int OPERATOR_ID = 1;
 
     /**
+     * How far in the future we should "lead" the aiming of the shooter for shooting while moving.
+     */
+    public static final double LEAD_GAIN = 0.3;
+
+    /**
      * Motor CAN id's.
      */
     public static final class Motors {
@@ -148,6 +153,10 @@ public final class Constants {
      * Swerve Constants
      */
     public static final class Swerve {
+        public static final double AUTO_ROTATION_KP = 5.0;
+        public static final double AUTO_ROTATION_KI = 0.0;
+        public static final double AUTO_ROTATION_KD = 0.0;
+
         public static final edu.wpi.first.wpilibj.SPI.Port navXID =
             edu.wpi.first.wpilibj.SPI.Port.kMXP;
         public static final boolean invertGyro = true;
@@ -273,7 +282,7 @@ public final class Constants {
 
         public static final HolonomicPathFollowerConfig pathFollowerConfig =
             new HolonomicPathFollowerConfig(new PIDConstants(5.0, 0, 0), // Translation constants
-                new PIDConstants(5.0, 0, 0), // Rotation constants
+                new PIDConstants(AUTO_ROTATION_KP, AUTO_ROTATION_KI, AUTO_ROTATION_KD), // Rotation constants
                 // Drive base radius (distance from center to furthest module)
                 maxSpeed, MOD0_MODOFFSET.getNorm(), new ReplanningConfig());
     }

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -108,8 +108,8 @@ public final class Constants {
             public static final double PITCH = Math.toRadians(5);
             public static final double YAW = Math.toRadians(-10);
             public static final Transform3d KCAMERA_TO_ROBOT =
-                new Transform3d(new Translation3d(Units.inchesToMeters(3.96),
-                    Units.inchesToMeters(11.013), Units.inchesToMeters(18.074)),
+                new Transform3d(new Translation3d(Units.inchesToMeters(11.013),
+                    Units.inchesToMeters(-10.96), Units.inchesToMeters(18.074)),
                     new Rotation3d(ROLL, PITCH, YAW)).inverse();
 
             public static final String CAMERA_NAME = "front-right";
@@ -283,7 +283,8 @@ public final class Constants {
 
         public static final HolonomicPathFollowerConfig pathFollowerConfig =
             new HolonomicPathFollowerConfig(new PIDConstants(5.0, 0, 0), // Translation constants
-                new PIDConstants(AUTO_ROTATION_KP, AUTO_ROTATION_KI, AUTO_ROTATION_KD), // Rotation constants
+                new PIDConstants(AUTO_ROTATION_KP, AUTO_ROTATION_KI, AUTO_ROTATION_KD), // Rotation
+                                                                                        // constants
                 // Drive base radius (distance from center to furthest module)
                 maxSpeed, MOD0_MODOFFSET.getNorm(), new ReplanningConfig());
     }

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -65,7 +65,8 @@ public final class Constants {
          * Intake and indexer motor constants
          */
         public static final class Intake {
-            public static final int INTAKE_MOTOR_ID = 14;
+            public static final int INTAKE_MOTOR_ID_LEFT = 14;
+            public static final int INTAKE_MOTOR_ID_RIGHT = 61;
             public static final int INDEXER_MOTOR_ID = 32;
         }
 

--- a/src/main/java/frc/robot/OperatorState.java
+++ b/src/main/java/frc/robot/OperatorState.java
@@ -1,0 +1,64 @@
+package frc.robot;
+
+/** Singleton tracker for operator state. */
+public class OperatorState {
+
+    private OperatorState() {}
+
+    /** Operating state. */
+    public static enum State {
+        kAmp("Amp"), kShootPost("Shoot from Post"), kShootTrap("Shoot from Trap"), kShootWhileMove(
+            "Shoot while moving"), kClimb("Climb");
+
+        public final String displayName;
+
+        State(String displayName) {
+            this.displayName = displayName;
+        }
+
+        public State increment() {
+            int new_ordinal = this.ordinal() + 1;
+            if (new_ordinal >= State.values().length) {
+                return this;
+            }
+            return State.values()[new_ordinal];
+        }
+
+        public State decrement() {
+            int new_ordinal = this.ordinal() - 1;
+            if (new_ordinal < 0) {
+                return this;
+            }
+            return State.values()[new_ordinal];
+        }
+    }
+
+    private static State currentState = State.kAmp;
+    private static boolean manualMode = false;
+
+    /** Get whether or not operator should be able to control wrist and elevator manually. */
+    public static boolean manualModeEnabled() {
+        return manualMode;
+    }
+
+    /** Toggle manual mode for elevator/wrist. */
+    public static void toggleManualMode() {
+        manualMode = !manualMode;
+    }
+
+    /** Get currently tracked state. */
+    public static State getCurrentState() {
+        return currentState;
+    }
+
+    /** Advance state forward by one. */
+    public static void increment() {
+        currentState = currentState.increment();
+    }
+
+    /** Advance state backward by one. */
+    public static void decrement() {
+        currentState = currentState.decrement();
+    }
+
+}

--- a/src/main/java/frc/robot/OperatorState.java
+++ b/src/main/java/frc/robot/OperatorState.java
@@ -16,6 +16,7 @@ public class OperatorState {
             this.displayName = displayName;
         }
 
+        /** Get next state. */
         public State increment() {
             int new_ordinal = this.ordinal() + 1;
             if (new_ordinal >= State.values().length) {
@@ -24,6 +25,7 @@ public class OperatorState {
             return State.values()[new_ordinal];
         }
 
+        /** Get previous state. */
         public State decrement() {
             int new_ordinal = this.ordinal() - 1;
             if (new_ordinal < 0) {

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -68,7 +68,7 @@ public class Robot extends LoggedRobot {
 
         if (isReal()) {
             Logger.addDataReceiver(new WPILOGWriter("/media/sda1")); // Log to a USB stick
-            // Logger.addDataReceiver(new NT4Publisher()); // Publish data to NetworkTables
+            Logger.addDataReceiver(new NT4Publisher()); // Publish data to NetworkTables
             // new PowerDistribution(1, ModuleType.kRev); // Enables power distribution logging
             setUseTiming(true);
             robotRunType = RobotRunType.kReal;

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -14,6 +14,7 @@ import org.littletonrobotics.junction.Logger;
 import org.littletonrobotics.junction.networktables.NT4Publisher;
 import org.littletonrobotics.junction.wpilog.WPILOGReader;
 import org.littletonrobotics.junction.wpilog.WPILOGWriter;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
 
@@ -108,6 +109,9 @@ public class Robot extends LoggedRobot {
 
     @Override
     public void robotPeriodic() {
+        SmartDashboard.putString("Operator State", OperatorState.getCurrentState().displayName);
+        SmartDashboard.putBoolean("Operator Manual Mode", OperatorState.manualModeEnabled());
+
         // Runs the Scheduler. This is responsible for polling buttons, adding newly-scheduled
         // commands,
         // running already-scheduled commands, removing finished or interrupted commands, and
@@ -115,7 +119,6 @@ public class Robot extends LoggedRobot {
         // subsystem periodic() methods. This must be called from the robot's periodic block in
         // order for
         // anything in the Command-based framework to work.
-
         CommandScheduler.getInstance().run();
     }
 

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -14,6 +14,8 @@ import org.littletonrobotics.junction.Logger;
 import org.littletonrobotics.junction.networktables.NT4Publisher;
 import org.littletonrobotics.junction.wpilog.WPILOGReader;
 import org.littletonrobotics.junction.wpilog.WPILOGWriter;
+import edu.wpi.first.wpilibj.PowerDistribution;
+import edu.wpi.first.wpilibj.PowerDistribution.ModuleType;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
@@ -69,7 +71,7 @@ public class Robot extends LoggedRobot {
         if (isReal()) {
             Logger.addDataReceiver(new WPILOGWriter("/media/sda1")); // Log to a USB stick
             Logger.addDataReceiver(new NT4Publisher()); // Publish data to NetworkTables
-            // new PowerDistribution(1, ModuleType.kRev); // Enables power distribution logging
+            new PowerDistribution(1, ModuleType.kRev); // Enables power distribution logging
             setUseTiming(true);
             robotRunType = RobotRunType.kReal;
         } else {

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -9,9 +9,11 @@ import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.WaitCommand;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
+import frc.lib.util.MatchCommand;
 import frc.lib.util.photon.PhotonCameraWrapper;
 import frc.lib.util.photon.PhotonReal;
 import frc.robot.Robot.RobotRunType;
@@ -135,6 +137,19 @@ public class RobotContainer {
         operator.rightTrigger().whileTrue(CommandFactory.shootSpeaker(shooter, intake));
         operator.start().onTrue(elevatorWrist.ampPosition());
         operator.back().onTrue(elevatorWrist.homePosition());
+
+        operator.povRight().onTrue(Commands.runOnce(() -> {
+            OperatorState.increment();
+        }));
+        operator.povLeft().onTrue(Commands.runOnce(() -> {
+            OperatorState.decrement();
+        }));
+
+        operator.a().onTrue(new MatchCommand<OperatorState.State>(List.of(OperatorState.State.kAmp),
+            List.of(elevatorWrist.ampPosition()), OperatorState::getCurrentState));
+        operator.start().onTrue(Commands.runOnce(() -> {
+            OperatorState.toggleManualMode();
+        }));
 
         // operator.povDown().whileTrue(
         // elevatorWrist.goToPosition(Constants.ElevatorWristConstants.SetPoints.AMP_HEIGHT,

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -18,6 +18,7 @@ import frc.lib.util.photon.PhotonCameraWrapper;
 import frc.lib.util.photon.PhotonReal;
 import frc.robot.Robot.RobotRunType;
 import frc.robot.commands.CommandFactory;
+import frc.robot.commands.ShootWhileMoving;
 import frc.robot.commands.TeleopSwerve;
 import frc.robot.subsystems.climber.Climber;
 import frc.robot.subsystems.climber.ClimberIO;
@@ -131,22 +132,31 @@ public class RobotContainer {
         driver.rightTrigger().whileTrue(intake.runIntakeMotor(1, .20));
         // intake backward
         driver.b().whileTrue(intake.runIndexerMotor(-.1));
+        // intake and shoot as fast as possible
         driver.x().whileTrue(CommandFactory.passThroughShoot(shooter, intake));
+        // toggle shooting while moving
+        driver.a().toggleOnTrue(new ShootWhileMoving(s_Swerve, driver));
 
+        // spit note currently in robot through shooter
         operator.x().whileTrue(CommandFactory.spit(shooter, intake));
+        // shoot note to speaker after being intaked
         operator.rightTrigger().whileTrue(CommandFactory.shootSpeaker(shooter, intake));
+        // set shooter to amp scoring preset position
         operator.start().onTrue(elevatorWrist.ampPosition());
+        // set shooter to home preset position
         operator.back().onTrue(elevatorWrist.homePosition());
-
+        // increment once through states list to next state
         operator.povRight().onTrue(Commands.runOnce(() -> {
             OperatorState.increment();
         }));
+        // go back one through the states list to the previous state
         operator.povLeft().onTrue(Commands.runOnce(() -> {
             OperatorState.decrement();
         }));
-
+        // go to current state as incremented through operator states list
         operator.a().onTrue(new MatchCommand<OperatorState.State>(List.of(OperatorState.State.kAmp),
             List.of(elevatorWrist.ampPosition()), OperatorState::getCurrentState));
+        //
         operator.start().onTrue(Commands.runOnce(() -> {
             OperatorState.toggleManualMode();
         }));

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -76,18 +76,18 @@ public class RobotContainer {
              * Camera Order: 0 - Front Left 1 - Front RIght 2 - Back Left 3 - Back Right
              */
             new PhotonCameraWrapper[] {
-                new PhotonCameraWrapper(
-                    new PhotonReal(Constants.CameraConstants.FrontLeftFacingCamera.CAMERA_NAME),
-                    Constants.CameraConstants.FrontLeftFacingCamera.KCAMERA_TO_ROBOT),
+                // new PhotonCameraWrapper(
+                // new PhotonReal(Constants.CameraConstants.FrontLeftFacingCamera.CAMERA_NAME),
+                // Constants.CameraConstants.FrontLeftFacingCamera.KCAMERA_TO_ROBOT),
                 new PhotonCameraWrapper(
                     new PhotonReal(Constants.CameraConstants.FrontRightFacingCamera.CAMERA_NAME),
-                    Constants.CameraConstants.FrontRightFacingCamera.KCAMERA_TO_ROBOT),
-                new PhotonCameraWrapper(
-                    new PhotonReal(Constants.CameraConstants.BackLeftFacingCamera.CAMERA_NAME),
-                    Constants.CameraConstants.BackLeftFacingCamera.KCAMERA_TO_ROBOT),
-                new PhotonCameraWrapper(
-                    new PhotonReal(Constants.CameraConstants.BackRightFacingCamera.CAMERA_NAME),
-                    Constants.CameraConstants.BackRightFacingCamera.KCAMERA_TO_ROBOT)};
+                    Constants.CameraConstants.FrontRightFacingCamera.KCAMERA_TO_ROBOT)};
+        // new PhotonCameraWrapper(
+        // new PhotonReal(Constants.CameraConstants.BackLeftFacingCamera.CAMERA_NAME),
+        // Constants.CameraConstants.BackLeftFacingCamera.KCAMERA_TO_ROBOT),
+        // new PhotonCameraWrapper(
+        // new PhotonReal(Constants.CameraConstants.BackRightFacingCamera.CAMERA_NAME),
+        // Constants.CameraConstants.BackRightFacingCamera.KCAMERA_TO_ROBOT)};
 
         switch (runtimeType) {
             case kReal:
@@ -128,6 +128,8 @@ public class RobotContainer {
     private void configureButtonBindings() {
         /* Driver Buttons */
         driver.y().onTrue(new InstantCommand(() -> s_Swerve.resetFieldRelativeOffset()));
+        driver.start().onTrue(
+            new InstantCommand(() -> s_Swerve.resetPvInitialization()).ignoringDisable(true));
         // intake forward
         driver.rightTrigger().whileTrue(intake.runIntakeMotor(1, .20));
         // intake backward
@@ -135,7 +137,9 @@ public class RobotContainer {
         // intake and shoot as fast as possible
         driver.x().whileTrue(CommandFactory.passThroughShoot(shooter, intake));
         // toggle shooting while moving
-        driver.a().toggleOnTrue(new ShootWhileMoving(s_Swerve, driver));
+        driver.a().toggleOnTrue(
+            new ShootWhileMoving(s_Swerve, driver).alongWith(elevatorWrist.followPosition(() -> 0,
+                () -> elevatorWrist.getAngleFromDistance(s_Swerve.getPose()))));
 
         // spit note currently in robot through shooter
         operator.x().whileTrue(CommandFactory.spit(shooter, intake));

--- a/src/main/java/frc/robot/commands/ShootWhileMoving.java
+++ b/src/main/java/frc/robot/commands/ShootWhileMoving.java
@@ -5,6 +5,7 @@ import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Transform2d;
 import edu.wpi.first.math.geometry.Translation2d;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
 import frc.lib.util.FieldConstants;
@@ -27,6 +28,7 @@ public class ShootWhileMoving extends Command {
                                                                 // PathPlanner uses radians
                                                                 // internally. That way we can reuse
                                                                 // PID gains from autonomous.
+        pidController.setTolerance(Math.toRadians(.5));
     }
 
     @Override
@@ -46,11 +48,14 @@ public class ShootWhileMoving extends Command {
             new Transform2d(translation.times(Constants.LEAD_GAIN), Rotation2d.fromRotations(0)));
 
         Rotation2d desiredRotation = FieldConstants.Speaker.centerSpeakerOpening.getTranslation()
-            .minus(futurePose.getTranslation()).getAngle();
+            .minus(futurePose.getTranslation()).getAngle().plus(Rotation2d.fromDegrees(5));
 
+        SmartDashboard.putNumber("Move Shoot Desired Rotation", desiredRotation.getDegrees());
         pidController.setSetpoint(desiredRotation.getRadians());
-        double rotation = pidController.calculate(futurePose.getRotation().getRadians());
-
+        double rotation = pidController.calculate(swerveDrive.getPose().getRotation().getRadians());
+        if (pidController.atSetpoint()) {
+            rotation = 0;
+        }
         swerveDrive.drive(translation, rotation, true, false);
     }
 

--- a/src/main/java/frc/robot/commands/ShootWhileMoving.java
+++ b/src/main/java/frc/robot/commands/ShootWhileMoving.java
@@ -24,7 +24,7 @@ public class ShootWhileMoving extends Command {
         Constants.Swerve.AUTO_ROTATION_KI, Constants.Swerve.AUTO_ROTATION_KD);
 
     /**
-     * Shoot while moving comand
+     * Shoot while moving command
      *
      * @param swerveDrive Swerve Drive subsystem
      * @param controller Driver Controller

--- a/src/main/java/frc/robot/commands/ShootWhileMoving.java
+++ b/src/main/java/frc/robot/commands/ShootWhileMoving.java
@@ -1,0 +1,57 @@
+package frc.robot.commands;
+
+import edu.wpi.first.math.controller.PIDController;
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Transform2d;
+import edu.wpi.first.math.geometry.Translation2d;
+import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
+import frc.lib.util.FieldConstants;
+import frc.robot.Constants;
+import frc.robot.subsystems.swerve.Swerve;
+
+public class ShootWhileMoving extends Command {
+
+    private Swerve swerveDrive;
+    private CommandXboxController controller;
+
+    private PIDController pidController = new PIDController(Constants.Swerve.AUTO_ROTATION_KP,
+        Constants.Swerve.AUTO_ROTATION_KI, Constants.Swerve.AUTO_ROTATION_KD);
+
+    public ShootWhileMoving(Swerve swerveDrive, CommandXboxController controller) {
+        this.swerveDrive = swerveDrive;
+        addRequirements(swerveDrive);
+        this.controller = controller;
+        pidController.enableContinuousInput(-Math.PI, Math.PI); // We use radians here because
+                                                                // PathPlanner uses radians
+                                                                // internally. That way we can reuse
+                                                                // PID gains from autonomous.
+    }
+
+    @Override
+    public void execute() {
+        double yaxis = -controller.getLeftY();
+        double xaxis = -controller.getLeftX();
+
+        /* Deadbands */
+        yaxis = (Math.abs(yaxis) < Constants.STICK_DEADBAND) ? 0 : yaxis;
+        xaxis = (Math.abs(xaxis) < Constants.STICK_DEADBAND) ? 0 : xaxis;
+        // System.out.println(swerveDrive.getStringYaw());
+
+        Translation2d translation =
+            new Translation2d(yaxis, xaxis).times(Constants.Swerve.maxSpeed);
+
+        Pose2d futurePose = swerveDrive.getPose().plus(
+            new Transform2d(translation.times(Constants.LEAD_GAIN), Rotation2d.fromRotations(0)));
+
+        Rotation2d desiredRotation = FieldConstants.Speaker.centerSpeakerOpening.getTranslation()
+            .minus(futurePose.getTranslation()).getAngle();
+
+        pidController.setSetpoint(desiredRotation.getRadians());
+        double rotation = pidController.calculate(futurePose.getRotation().getRadians());
+
+        swerveDrive.drive(translation, rotation, true, false);
+    }
+
+}

--- a/src/main/java/frc/robot/commands/ShootWhileMoving.java
+++ b/src/main/java/frc/robot/commands/ShootWhileMoving.java
@@ -12,6 +12,9 @@ import frc.lib.util.FieldConstants;
 import frc.robot.Constants;
 import frc.robot.subsystems.swerve.Swerve;
 
+/**
+ * Shooting while moving command
+ */
 public class ShootWhileMoving extends Command {
 
     private Swerve swerveDrive;
@@ -20,14 +23,19 @@ public class ShootWhileMoving extends Command {
     private PIDController pidController = new PIDController(Constants.Swerve.AUTO_ROTATION_KP,
         Constants.Swerve.AUTO_ROTATION_KI, Constants.Swerve.AUTO_ROTATION_KD);
 
+    /**
+     * Shoot while moving comand
+     *
+     * @param swerveDrive Swerve Drive subsystem
+     * @param controller Driver Controller
+     */
     public ShootWhileMoving(Swerve swerveDrive, CommandXboxController controller) {
         this.swerveDrive = swerveDrive;
         addRequirements(swerveDrive);
         this.controller = controller;
-        pidController.enableContinuousInput(-Math.PI, Math.PI); // We use radians here because
-                                                                // PathPlanner uses radians
-                                                                // internally. That way we can reuse
-                                                                // PID gains from autonomous.
+        // We use radians here because PathPlanner uses radians internally. That way we can reuse
+        // PID gains from autonomous.
+        pidController.enableContinuousInput(-Math.PI, Math.PI);
         pidController.setTolerance(Math.toRadians(.5));
     }
 

--- a/src/main/java/frc/robot/subsystems/climber/ClimberIO.java
+++ b/src/main/java/frc/robot/subsystems/climber/ClimberIO.java
@@ -12,12 +12,12 @@ public interface ClimberIO {
      */
     @AutoLog
     public static class ClimberInputs {
-        public double climberLeftMotorVoltage;
-        public double climberLeftMotorAmp;
-        public double climberRightMotorTemp;
-        public double climberRightMotorVoltage;
-        public double climberRightMotorAmp;
-        public double climberLeftMotorTemp;
+        // public double climberLeftMotorVoltage;
+        // public double climberLeftMotorAmp;
+        // public double climberRightMotorTemp;
+        // public double climberRightMotorVoltage;
+        // public double climberRightMotorAmp;
+        // public double climberLeftMotorTemp;
         public double leftMotorEncoderValue;
         public double rightMotorEncoderValue;
 

--- a/src/main/java/frc/robot/subsystems/climber/ClimberNEO.java
+++ b/src/main/java/frc/robot/subsystems/climber/ClimberNEO.java
@@ -35,12 +35,12 @@ public class ClimberNEO implements ClimberIO {
 
     @Override
     public void updateInputs(ClimberInputs inputs) {
-        inputs.climberLeftMotorVoltage = leftMotor.getBusVoltage();
-        inputs.climberLeftMotorAmp = leftMotor.getOutputCurrent();
-        inputs.climberLeftMotorTemp = leftMotor.getMotorTemperature();
-        inputs.climberRightMotorVoltage = rightMotor.getBusVoltage();
-        inputs.climberRightMotorAmp = rightMotor.getOutputCurrent();
-        inputs.climberRightMotorTemp = rightMotor.getMotorTemperature();
+        // inputs.climberLeftMotorVoltage = leftMotor.getBusVoltage();
+        // inputs.climberLeftMotorAmp = leftMotor.getOutputCurrent();
+        // inputs.climberLeftMotorTemp = leftMotor.getMotorTemperature();
+        // inputs.climberRightMotorVoltage = rightMotor.getBusVoltage();
+        // inputs.climberRightMotorAmp = rightMotor.getOutputCurrent();
+        // inputs.climberRightMotorTemp = rightMotor.getMotorTemperature();
         inputs.leftMotorEncoderValue = leftRelativeEncoder.getPosition();
         inputs.rightMotorEncoderValue = rightRelativeEncoder.getPosition();
 

--- a/src/main/java/frc/robot/subsystems/elevator_wrist/ElevatorWrist.java
+++ b/src/main/java/frc/robot/subsystems/elevator_wrist/ElevatorWrist.java
@@ -192,6 +192,12 @@ public class ElevatorWrist extends SubsystemBase {
                 + Constants.ElevatorWristConstants.WRIST_B);
     }
 
+    /**
+     * Determine the angle of wrist based on the distance from the shooter
+     *
+     * @param position Position of the robot
+     * @return Rotation of the wrist
+     */
     public Rotation2d getAngleFromDistance(Pose2d position) {
         double distFromSpeaker = position.getTranslation()
             .minus(FieldConstants.Speaker.centerSpeakerOpening.getTranslation()).getNorm();
@@ -199,6 +205,11 @@ public class ElevatorWrist extends SubsystemBase {
         return Rotation2d.fromDegrees(radiusToAngle.get(distFromSpeaker));
     }
 
+    /**
+     * Set the Wrist to a specified angle
+     * 
+     * @param angle Angle of the wrist
+     */
     public void setWristAngle(Rotation2d angle) {
         wristPIDController.setSetpoint(angle.getRotations());
         wristProfiledPIDController.setSetpoint(angle.getRotations());

--- a/src/main/java/frc/robot/subsystems/elevator_wrist/ElevatorWrist.java
+++ b/src/main/java/frc/robot/subsystems/elevator_wrist/ElevatorWrist.java
@@ -207,7 +207,7 @@ public class ElevatorWrist extends SubsystemBase {
 
     /**
      * Set the Wrist to a specified angle
-     * 
+     *
      * @param angle Angle of the wrist
      */
     public void setWristAngle(Rotation2d angle) {

--- a/src/main/java/frc/robot/subsystems/intake/Intake.java
+++ b/src/main/java/frc/robot/subsystems/intake/Intake.java
@@ -46,13 +46,13 @@ public class Intake extends SubsystemBase {
      * @return {@link Command} to run the intake and indexer motors
      */
     public Command runIntakeMotor(double intakeSpeed, double indexerSpeed) {
-        return Commands.startEnd(() -> {
+        return Commands.run(() -> {
             setIntakeMotor(intakeSpeed);
             setIndexerMotor(indexerSpeed);
-        }, () -> {
+        }, this).finallyDo((_x) -> {
             setIntakeMotor(0);
             setIndexerMotor(0);
-        }, this).until(() -> !getSensorStatus()).unless(() -> !getSensorStatus());
+        }).until(() -> !getSensorStatus()).unless(() -> !getSensorStatus());
     }
 
     /**

--- a/src/main/java/frc/robot/subsystems/intake/IntakeIO.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeIO.java
@@ -17,11 +17,9 @@ public interface IntakeIO {
         public double intakeMotorVoltage;
         public double indexerMotorVoltage;
         public double intakeAmps;
-        public double intakeTemp;
         public double indexerAmps;
         public double intakeRPM;
         public double indexerRPM;
-        public double indexerTemp;
         public boolean sensorStatus;
     }
 

--- a/src/main/java/frc/robot/subsystems/intake/IntakeIO.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeIO.java
@@ -12,14 +12,14 @@ public interface IntakeIO {
      */
     @AutoLog
     public static class IntakeInputs {
-        public double intakeSupplyVoltage;
-        public double indexerSupplyVoltage;
-        public double intakeMotorVoltage;
-        public double indexerMotorVoltage;
-        public double intakeAmps;
-        public double indexerAmps;
-        public double intakeRPM;
-        public double indexerRPM;
+        // public double intakeSupplyVoltage;
+        // public double indexerSupplyVoltage;
+        // public double intakeMotorVoltage;
+        // public double indexerMotorVoltage;
+        // public double intakeAmps;
+        // public double indexerAmps;
+        // public double intakeRPM;
+        // public double indexerRPM;
         public boolean sensorStatus;
     }
 

--- a/src/main/java/frc/robot/subsystems/intake/IntakeIOFalcon.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeIOFalcon.java
@@ -40,13 +40,13 @@ public class IntakeIOFalcon implements IntakeIO {
 
     @Override
     public void updateInputs(IntakeInputs inputs) {
-        inputs.intakeSupplyVoltage = intakeMotorLeft.getBusVoltage();
-        inputs.intakeAmps = intakeMotorLeft.getOutputCurrent();
-        inputs.intakeRPM = intakeRelativeEnc.getVelocity();
-        inputs.indexerSupplyVoltage = indexerMotor.getSupplyVoltage().getValueAsDouble();
-        inputs.indexerMotorVoltage = indexerMotor.getMotorVoltage().getValueAsDouble();
-        inputs.indexerAmps = indexerMotor.getSupplyCurrent().getValueAsDouble();
-        inputs.indexerRPM = indexerMotor.getVelocity().getValueAsDouble();
+        // inputs.intakeSupplyVoltage = intakeMotorLeft.getBusVoltage();
+        // inputs.intakeAmps = intakeMotorLeft.getOutputCurrent();
+        // inputs.intakeRPM = intakeRelativeEnc.getVelocity();
+        // inputs.indexerSupplyVoltage = indexerMotor.getSupplyVoltage().getValueAsDouble();
+        // inputs.indexerMotorVoltage = indexerMotor.getMotorVoltage().getValueAsDouble();
+        // inputs.indexerAmps = indexerMotor.getSupplyCurrent().getValueAsDouble();
+        // inputs.indexerRPM = indexerMotor.getVelocity().getValueAsDouble();
         inputs.sensorStatus = beamBrake.get(); // true == no game piece
     }
 

--- a/src/main/java/frc/robot/subsystems/intake/IntakeIOFalcon.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeIOFalcon.java
@@ -15,10 +15,12 @@ import frc.robot.Constants;
  */
 public class IntakeIOFalcon implements IntakeIO {
 
-    private final CANSparkMax intakeMotor =
-        new CANSparkMax(Constants.Motors.Intake.INTAKE_MOTOR_ID, MotorType.kBrushless);
+    private final CANSparkMax intakeMotorLeft =
+        new CANSparkMax(Constants.Motors.Intake.INTAKE_MOTOR_ID_LEFT, MotorType.kBrushless);
+    private final CANSparkMax intakeMotorRight =
+        new CANSparkMax(Constants.Motors.Intake.INTAKE_MOTOR_ID_RIGHT, MotorType.kBrushless);
     public final RelativeEncoder intakeRelativeEnc =
-        intakeMotor.getEncoder(SparkRelativeEncoder.Type.kHallSensor, 42);
+        intakeMotorLeft.getEncoder(SparkRelativeEncoder.Type.kHallSensor, 42);
     private final TalonFX indexerMotor = new TalonFX(Constants.Motors.Intake.INDEXER_MOTOR_ID);
 
     private final DutyCycleOut indexerDutyCycleOut = new DutyCycleOut(0);
@@ -28,28 +30,31 @@ public class IntakeIOFalcon implements IntakeIO {
      * Intake IO Layer with real motors and sensors
      */
     public IntakeIOFalcon() {
-        intakeMotor.setInverted(Constants.IntakeConstants.INTAKE_MOTOR_INVERTED);
-        intakeMotor.setIdleMode(IdleMode.kCoast);
+        intakeMotorLeft.setInverted(Constants.IntakeConstants.INTAKE_MOTOR_INVERTED);
+        intakeMotorLeft.setIdleMode(IdleMode.kCoast);
+        intakeMotorRight.restoreFactoryDefaults();
+        intakeMotorRight.setInverted(false);
         indexerMotor.setInverted(true);
     }
 
     @Override
     public void updateInputs(IntakeInputs inputs) {
-        inputs.intakeSupplyVoltage = intakeMotor.getBusVoltage();
-        inputs.intakeAmps = intakeMotor.getOutputCurrent();
+        inputs.intakeSupplyVoltage = intakeMotorLeft.getBusVoltage();
+        inputs.intakeAmps = intakeMotorLeft.getOutputCurrent();
         inputs.intakeRPM = intakeRelativeEnc.getVelocity();
-        inputs.intakeTemp = intakeMotor.getMotorTemperature();
+        // inputs.intakeTemp = intakeMotorLeft.getMotorTemperature();
         inputs.indexerSupplyVoltage = indexerMotor.getSupplyVoltage().getValueAsDouble();
         inputs.indexerMotorVoltage = indexerMotor.getMotorVoltage().getValueAsDouble();
         inputs.indexerAmps = indexerMotor.getSupplyCurrent().getValueAsDouble();
         inputs.indexerRPM = indexerMotor.getVelocity().getValueAsDouble();
-        inputs.indexerTemp = indexerMotor.getDeviceTemp().getValueAsDouble();
+        // inputs.indexerTemp = indexerMotor.getDeviceTemp().getValueAsDouble();
         inputs.sensorStatus = beamBrake.get(); // true == no game piece
     }
 
     @Override
     public void setIntakeMotorPercentage(double percent) {
-        intakeMotor.set(percent);
+        intakeMotorLeft.set(percent);
+        intakeMotorRight.set(percent);
     }
 
     @Override

--- a/src/main/java/frc/robot/subsystems/shooter/ShooterIO.java
+++ b/src/main/java/frc/robot/subsystems/shooter/ShooterIO.java
@@ -14,16 +14,16 @@ public interface ShooterIO {
     public static class ShooterIOInputs {
         public double topShooterVelocityRotPerMin;
         public double bottomShooterVelocityRotPerMin;
-        public double topShooterSupplyVoltage;
-        public double bottomShooterSupplyVoltage;
-        public double topShooterAmps;
-        public double bottomShooterAmps;
-        public double topShooterPosition;
-        public double bottomShooterPosition;
-        public double topShooterPower;
-        public double bottomShooterPower;
-        public double topShooterTemp;
-        public double bottomShooterTemp;
+        // public double topShooterSupplyVoltage;
+        // public double bottomShooterSupplyVoltage;
+        // public double topShooterAmps;
+        // public double bottomShooterAmps;
+        // public double topShooterPosition;
+        // public double bottomShooterPosition;
+        // public double topShooterPower;
+        // public double bottomShooterPower;
+        // public double topShooterTemp;
+        // public double bottomShooterTemp;
     }
 
     public default void setTopMotor(double power) {}

--- a/src/main/java/frc/robot/subsystems/shooter/ShooterVortex.java
+++ b/src/main/java/frc/robot/subsystems/shooter/ShooterVortex.java
@@ -50,15 +50,15 @@ public class ShooterVortex implements ShooterIO {
     public void updateInputs(ShooterIOInputsAutoLogged inputs) {
         inputs.topShooterVelocityRotPerMin = topEncoder.getVelocity();
         inputs.bottomShooterVelocityRotPerMin = bottomEncoder.getVelocity();
-        inputs.topShooterPosition = topEncoder.getPosition();
-        inputs.bottomShooterPosition = bottomEncoder.getPosition();
-        inputs.topShooterSupplyVoltage = topShooterMotor.getBusVoltage();
-        inputs.bottomShooterSupplyVoltage = topShooterMotor.getBusVoltage();
-        inputs.topShooterAmps = topShooterMotor.getOutputCurrent();
-        inputs.bottomShooterAmps = topShooterMotor.getOutputCurrent();
-        inputs.topShooterPower = topShooterMotor.get();
-        inputs.bottomShooterPower = bottomShooterMotor.get();
-        inputs.topShooterTemp = topShooterMotor.getMotorTemperature();
-        inputs.bottomShooterTemp = bottomShooterMotor.getMotorTemperature();
+        // inputs.topShooterPosition = topEncoder.getPosition();
+        // inputs.bottomShooterPosition = bottomEncoder.getPosition();
+        // inputs.topShooterSupplyVoltage = topShooterMotor.getBusVoltage();
+        // inputs.bottomShooterSupplyVoltage = topShooterMotor.getBusVoltage();
+        // inputs.topShooterAmps = topShooterMotor.getOutputCurrent();
+        // inputs.bottomShooterAmps = topShooterMotor.getOutputCurrent();
+        // inputs.topShooterPower = topShooterMotor.get();
+        // inputs.bottomShooterPower = bottomShooterMotor.get();
+        // inputs.topShooterTemp = topShooterMotor.getMotorTemperature();
+        // inputs.bottomShooterTemp = bottomShooterMotor.getMotorTemperature();
     }
 }

--- a/vendordeps/photonlib.json
+++ b/vendordeps/photonlib.json
@@ -1,7 +1,7 @@
 {
     "fileName": "photonlib.json",
     "name": "photonlib",
-    "version": "v2024.2.4",
+    "version": "v2024.2.8",
     "uuid": "515fe07e-bfc6-11fa-b3de-0242ac130004",
     "frcYear": "2024",
     "mavenUrls": [
@@ -14,7 +14,7 @@
         {
             "groupId": "org.photonvision",
             "artifactId": "photonlib-cpp",
-            "version": "v2024.2.4",
+            "version": "v2024.2.8",
             "libName": "photonlib",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -29,7 +29,7 @@
         {
             "groupId": "org.photonvision",
             "artifactId": "photontargeting-cpp",
-            "version": "v2024.2.4",
+            "version": "v2024.2.8",
             "libName": "photontargeting",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -46,12 +46,12 @@
         {
             "groupId": "org.photonvision",
             "artifactId": "photonlib-java",
-            "version": "v2024.2.4"
+            "version": "v2024.2.8"
         },
         {
             "groupId": "org.photonvision",
             "artifactId": "photontargeting-java",
-            "version": "v2024.2.4"
+            "version": "v2024.2.8"
         }
     ]
 }


### PR DESCRIPTION
Add `OperatorState` which allows for different "modes" for the operator. 

- `kAmp`: when the action button is pressed, the elevator and wrist go to amp outtake position.
- `kShootPost`: when the action button is pressed, the elevator goes to zero position and wrist aims for speaker assuming robot is against the stage post. Overrides driver rotation to aim for center of speaker.
- `kShootTrap`: when the action button is pressed, the elevator goes to zero position and wrist aims for speaker assuming robot is roughly aligned with the stage center (or trap). Overrides driver rotation to aim for center of speaker.
- `kShootWhileMove`: when the action button is pressed, the elevator goes to zero position and wrist aims for speaker using estimated robot pose. Overrides driver rotation to aim for center of speaker.
- `kClimb`: when the action button is pressed, the elevator lifts to climb height. In this mode, shooter buttons are replaced with climbing buttons.

Likely these will change as we get a better idea of how we want to run teleop.