### PR TITLE
PhotonVision filtering

### DIFF
--- a/src/main/java/frc/lib/util/photon/PhotonCameraWrapper.java
+++ b/src/main/java/frc/lib/util/photon/PhotonCameraWrapper.java
@@ -40,8 +40,8 @@ public class PhotonCameraWrapper {
         // field.
         AprilTagFieldLayout fieldLayout = AprilTagFields.k2024Crescendo.loadAprilTagLayoutField();
         // Create pose estimator
-        photonPoseEstimator = new PhotonIOPoseEstimator(fieldLayout,
-            PoseStrategy.MULTI_TAG_PNP_ON_COPROCESSOR, this.inputs, robotToCam);
+        photonPoseEstimator = new PhotonIOPoseEstimator(fieldLayout, PoseStrategy.LOWEST_AMBIGUITY,
+            this.inputs, robotToCam);
         photonPoseEstimator.setMultiTagFallbackStrategy(PoseStrategy.CLOSEST_TO_CAMERA_HEIGHT);
     }
 

--- a/src/main/java/frc/lib/util/photon/PhotonCameraWrapper.java
+++ b/src/main/java/frc/lib/util/photon/PhotonCameraWrapper.java
@@ -60,11 +60,13 @@ public class PhotonCameraWrapper {
         return inputs.result.hasTargets();
     }
 
+    /** A PhotonVision tag solve. */
     public static class VisionObservation {
         public int fudicialId;
         public Pose2d robotPose;
         public Matrix<N3, N1> stdDev;
 
+        /** All fields constructor. */
         public VisionObservation(int fudicialId, Pose2d robotPose, Matrix<N3, N1> stdDev) {
             this.fudicialId = fudicialId;
             this.robotPose = robotPose;

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -84,6 +84,9 @@ public final class Constants {
      */
     public static class CameraConstants {
 
+        public static double XY_STD_DEV_COEFF = 0.005;
+        public static double THETA_STD_DEV_COEFF = 0.01;
+
         /**
          * Constants for Front Left Camera
          */

--- a/src/main/java/frc/robot/OperatorState.java
+++ b/src/main/java/frc/robot/OperatorState.java
@@ -63,4 +63,35 @@ public class OperatorState {
         currentState = currentState.decrement();
     }
 
+    /**
+     * Only use certain tags in certain modes. Helps for incorrect field layouts during practice.
+     */
+    public static boolean tagFilter(int id) {
+        switch (getCurrentState()) {
+            case kAmp:
+                switch (id) {
+                    case 5:
+                    case 6:
+                        return true;
+                    default:
+                        break;
+                }
+                break;
+            case kShootWhileMove:
+                switch (id) {
+                    case 3:
+                    case 4:
+                    case 7:
+                    case 8:
+                        return true;
+                    default:
+                        break;
+                }
+                break;
+            default:
+                return true;
+        }
+        return false;
+    }
+
 }

--- a/src/main/java/frc/robot/OperatorState.java
+++ b/src/main/java/frc/robot/OperatorState.java
@@ -79,10 +79,8 @@ public class OperatorState {
                 break;
             case kShootWhileMove:
                 switch (id) {
-                    case 3:
                     case 4:
                     case 7:
-                    case 8:
                         return true;
                     default:
                         break;


### PR DESCRIPTION
Adds proper standard deviations to vision measurements.

Also filters fudicial ids based on OperatorState. This way, we can do tests on incorrect field layouts.

Needs to be tested. Prerequisite for auto-amp aligning.